### PR TITLE
chore(ci): switch to Namespace runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ concurrency:
 
 jobs:
   ci-and-release:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-jetscale-build
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- release.yml (reusable): namespace-profile-jetscale-build (Multi-image Docker builds + Go tests)

This reusable workflow is used by backend-base and thruster.

Per DR-003 runner taxonomy.

audit_log:
- Prudence: Namespace runners provide persistent caching
- Symbiosis: Aligns with org-wide CI runner strategy

Made-with: Cursor